### PR TITLE
Updated GameScript.yarn on script-update-dec5 | 12/7

### DIFF
--- a/00 Unity Proj/Assets/Scripts/YarnSpinner/GameScript.yarn
+++ b/00 Unity Proj/Assets/Scripts/YarnSpinner/GameScript.yarn
@@ -7,11 +7,9 @@ tags:
 ---
 // Important Data Values
 <<declare $hasBoltCutters = false>>
-
+<<declare $hasCake = false>>
 
 <i>The manor has been locked down. Nobody in, nobody out, until you all figure out what happened to <b>him</b>.</i>
-    -> Test This Button
-        <<jump TalkCAM_First>>
 ===
 
 title: TalkCAM_First
@@ -29,19 +27,30 @@ C.A.M.: Someone here wanted him gone.
 title: TalkADAM_First
 tags:
 ---
-<i>He's obviously in distress.</i>
-ADAM: I-I can't believe this. Who would do this!? Who would kill him?
+// Temporary variables - possibly delete?
+<<declare $asked_who = false>>
+<<declare $asked_guesses = false>>
+<<declare $asked_itsok = false>>
+
+ADAM:
+    <i>He's obviously in distress.</i>
+    ADAM: I-I can't believe this. Who would do this!? Who would kill him?
     -> I don't know, but I'll figure it out.
+        <<set $asked_who = true>>
         ADAM: ...Good luck. You'll need it.
-        <<jump TalkADAM_First>>
+         <<jump TalkADAM_First>>
     -> Do you have any guesses?
+        <<set $asked_guesses = true>>
         ADAM: ...Why would I? Who would do such a thing?!
-        <<jump TalkADAM_First>>
         <i>He seems inconsolable.</i>
+        <<jump TalkADAM_First>>
     -> It'll be okay, ADAM.
+        <<set $asked_itsok = true>>
         ADAM: I don't think so, but... if you say so...
         <<jump TalkADAM_First>>
     -> Good-bye, ADAM.
+            <<stop>>
+    <<jump TalkADAM_First>>
 ===
 
 title: TalkSPARK_First
@@ -62,7 +71,7 @@ SPARK: Bolt cutters... The chandelier does not look too well. I know that ADAM w
 title: QuestionSPARK
 tags:
 ---
-SPARK: What? What's going on?
+SPARK: What? What's going on? Any new findings?
     -> Do you have any suspicions?
         SPARK: I truly don't know who would do this to him. But, this was C.A.M.'s retirement...
         <<jump QuestionSPARK>>
@@ -71,16 +80,66 @@ SPARK: What? What's going on?
         <<jump QuestionSPARK>>
     -> What were you doing <i>when</i> Geoffrey died?
         SPARK: Still working on dessert! A lemon meringue, one of his favorites. This is such a travesty. Here, if it'll help you, you can have some of the cake.
-        // Cake is clue?
+        <i>You receive a piece of lemon meringue cake.</i>
+        <<set $hasCake = true>>
         <<jump QuestionSPARK>>
     -> What do you know about the bolt cutters?
+        SPARK: Why were there bolt cutters out here? That's... <i>she pauses, obviously confused.</i> I don't understand why they would be here.
         <<jump QuestionSPARK>>
     -> What do you know about the broken circuit breaker?
+    <<if $hasBoltCutters == false>>
+    SPARK: Well, I didn't know it was broken.
+    <<else>>
+    SPARK: Well, I didn't know it was broken.
+    SPARK: ...
+    SPARK: Bolt cutters, and a broken circuit breaker... I don't like the look of this, P.A.M.
+    <<endif>>
         <<jump QuestionSPARK>>
-    -> I don't have anymore questions.
-        // SPARK reaction? or just quit out of dialogue maybe?
+    -> Who do <i>you</i> think is guilty?
+        SPARK: Guilty? I... ADAM. With the bolt cutters, it all points to him.
+        <<jump QuestionSPARK>>
+    -> I don't have any more questions.
+        <<stop>>
 ===
 
+title: QuestionADAM
+tags:
+---
+ADAM: How's the investigation going? ...Have you figured anything else out?
+    -> Do you have any suspicions?
+        ADAM: ...I really don't know where to start.
+        <<jump QuestionADAM>>
+    -> What were you doing <i>before</i> Geoffrey died?
+        ADAM: I was really just coming down here. For dinner.
+        <<jump QuestionADAM>>
+    -> What were you doing <i>when</i> Geoffrey died?
+        ADAM: ...Well, nothing. The power went out. Really, I was just standing there, waiting for the generators to begin working.
+        <<jump QuestionADAM>>
+    -> Who do <i>you</i> think is guilty?
+        ADAM: Oh, P.A.M... I... I don't know.
+    -> I don't have any more questions.
+        <<stop>>
+===
+
+title: QuestionCAM
+tags:
+---
+CAM: P.A.M., I'm glad to see you.
+    -> Do you have any suspicions?
+        CAM: Someone must have... Who would hurt- no, who would kill him? I... The chandelier. How did it fall?
+        <<jump QuestionCAM>>
+    -> What were you doing <i>before</i> Geoffrey died?
+        CAM: Me? Why, I was spending time with Geoffrey. Discussing my retirement.
+        <<jump QuestionCAM>>
+    -> What were you doing <i>when</i> Geoffrey died?
+        CAM: You're being rather thorough. I was simply helping with final preparations for the meal!
+        <<jump QuestionCAM>>
+    -> Who do <i>you</i> think is guilty?
+        CAM: Goodness... P.A.M., that is a very tough question.
+        <<jump QuestionCAM>>
+    -> I don't have any more questions.
+        <<stop>>
+===
 
 //this is for testing purposes, delete later
 title: Test_ItemDesc
@@ -93,8 +152,14 @@ tags:
         <<jump Observe_Clock>>
     -> Bolt Cutters
         <<jump Observe_BoltCutters>>
-    -> Chandelier
+    -> Chandelier That Was Cut
         <<jump Observe_Chandelier>>
+    -> Oven That Is Left On
+        <<jump Observe_Oven>>
+    -> Dining Room Table
+        <<jump Observe_DiningRoomTable>>
+    -> Chairs
+        <<jump Observe_Chairs>>
     -> Geoffrey
         <<jump Observe_Geoffrey>>
     -> Quit.
@@ -132,7 +197,31 @@ Bolt Cutters: <i>Rusty, old bolt cutters. They haven't been used in quite some t
 title: Observe_Chandelier
 tags:
 ---
-Broken Chandelier: <i>This is what fell on Geoffrey. The glass has shattered, spread all over the table in a beautiful display of destruction.</i>
+Chandelier That Was Cut: <i>This is what fell on Geoffrey. The glass has shattered, spread all over the table in a beautiful display of destruction.</i>
+<<jump Test_ItemDesc>> // Testing/debugging purposes
+===
+
+title: Observe_Oven
+tags:
+---
+Oven That Is Left On: <i>...</i>
+SPARK: My precious art!!! It burned because I couldn't seen in the dark! Curse whoever did this, first Dad, now my luxury cake, everything is ruined!!!
+<<jump Test_ItemDesc>> // Testing/debugging purposes
+===
+
+
+title: Observe_DiningRoomTable
+tags:
+---
+Dining Room Table: <i>The dining room table. A simple piece of furniture, but one that holds a thousand memories. Dad used to sit at the end...</i>
+<<jump Test_ItemDesc>> // Testing/debugging purposes
+===
+
+
+title: Observe_Chairs
+tags:
+---
+Chairs: <i>Chairs for sitting down if your legs get tired. We're all robots except for Dad, so to us it is a just a formality to sit. It's impossible for us to get fatigued.</i>
 <<jump Test_ItemDesc>> // Testing/debugging purposes
 ===
 


### PR DESCRIPTION
### Overview
- Pulling the latest version of [`script-update-dec5`](https://github.com/Atomic-Atlas/MaS/tree/script-update-dec5) into [`dev`](https://github.com/Atomic-Atlas/MaS/tree/dev).

### In-depth Details
- The [`script-update-dec5`](https://github.com/Atomic-Atlas/MaS/tree/script-update-dec5) branch was created two days ago, with the intention of updating the [GameScript.yarn](https://github.com/Atomic-Atlas/MaS/blob/script-update-dec5/00%20Unity%20Proj/Assets/Scripts/YarnSpinner/GameScript.yarn) file.
     - This is the file that is formatted in [YarnSpinner](https://docs.yarnspinner.dev/) language to function with the Dialogue Runner in the game.
- @amazurr was able to update it quite a bit (see Commit 7b26cc53610537eaf79acd48b7ae86502c5cc7e5 for more information).
- My intention is to implement what they were able to provide, and see if I can continue it properly.